### PR TITLE
Fixed indenting with tabs too eagerly

### DIFF
--- a/IndentSize.py
+++ b/IndentSize.py
@@ -28,7 +28,7 @@ class IndentSizeCommand(sublime_plugin.TextCommand):
         # How many spaces are there from the last tab stop:
         trailing_tab = min(indentation_length % tab_size, trailing_spaces)
 
-        if tab_size == indent_size or trailing_tab >= indent_size:
+        if tab_size == indent_size or trailing_tab + indent_size == tab_size:
             trailing = trailing_tab
             tab = "\t"
         else:


### PR DESCRIPTION
Fixes issue when tab_size / indentation_size != 2. Previously this
caused every other tab press to emit \t whether or not tab_size
was reached.

Example when tab_size = 8, indentation_size = 2:

```
""
*tab*
"  "
*tab*
"\t"
*tab*
"\t  "
```

and so on.

The fix checks if trailing tab would reach tab_size after indentation.
